### PR TITLE
Properly finds libraries and header files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Sodium"
+    name: "Sodium",
+    pkgConfig: "libsodium"
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module Sodium [system] {
-  header "/usr/local/include/sodium.h"
+  header "shim.h"
   link "sodium"
   export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,6 @@
+#ifndef __SODIUM_SHIM_H__
+#define __SODIUM_SHIM_H__
+
+#include <sodium.h>
+
+#endif


### PR DESCRIPTION
- Added `pkgConfig: "libsodium"` to the Package.swift, which will allow the Swift package manager to get the proper include directories and linker search directories.
- Switched the explicit include of `/usr/local/include/sodium.h` with a shim that includes `<sodium.h>`, which should resolve to the correct header even if it isn't in `/usr/local/include/sodium.h`